### PR TITLE
[#28] Fix parser regex

### DIFF
--- a/src/core/parser.rs
+++ b/src/core/parser.rs
@@ -39,8 +39,8 @@ impl<'a> Parser<'a> {
     ///
     /// * `current_dir` - A reference to the base directory where the parser will operate.
     pub fn new(current_dir: &'a Path) -> Self {
-        let class_name_regex = Regex::new(r#"className="([^"]*)""#).unwrap();
-        let class_regex = Regex::new(r#"class="([^"]*)""#).unwrap();
+        let class_name_regex = Regex::new(r#"className=["|'|`](.*)["|'|`]"#).unwrap();
+        let class_regex = Regex::new(r#"class=["|'|`](.*)["|'|`]"#).unwrap();
         let tepmplated_spell_regex = Regex::new(r#"(g!\S*?;)"#).unwrap();
 
         Self {


### PR DESCRIPTION
### Problem

The parser only handled elements with double quotes.

### Solution

The regexes have been improved to support all kinds of quotes.

---

Closes #28 