### PR TITLE
Enhanced CLI functionality

### DIFF
--- a/src/core/grimoire_css_error.rs
+++ b/src/core/grimoire_css_error.rs
@@ -19,6 +19,7 @@ pub enum GrimoireCSSError {
     InvalidInput(String),
     InvalidPath(String),
     GlobPatternError(String),
+    RuntimeError(String),
 }
 
 impl fmt::Display for GrimoireCSSError {
@@ -31,6 +32,7 @@ impl fmt::Display for GrimoireCSSError {
             GrimoireCSSError::InvalidInput(s) => write!(f, "Invalid input: {}", s),
             GrimoireCSSError::InvalidPath(s) => write!(f, "Invalid path: {}", s),
             GrimoireCSSError::GlobPatternError(s) => write!(f, "Glob pattern error: {}", s),
+            GrimoireCSSError::RuntimeError(s) => write!(f, "Runtime error: {}", s),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,13 @@
 //! The main library module that orchestrates the core functionality of the Grimoire CSS system.
 //!
-//! This module initializes the CSS optimizer and manages the execution of commands based on the
-//! provided mode. It serves as the entry point for building and optimizing CSS based on various
-//! configurations and inputs.
+//! This module provides:
+//! - A **pure** function `start` that executes the core logic of Grimoire CSS without
+//!   printing or side effects.
+//! - A **convenience** function [`start_as_cli`] for CLI usage. It includes logging,
+//!   timing, and user-facing output (spinners, styled text), but is _not idiomatic_
+//!   for a typical Rust library because it introduces side effects and depends on
+//!   console/UI crates. Use it only if you specifically want the same CLI behavior
+//!   outside of the main binary (e.g. in a Node.js wrapper).
 
 mod buffer;
 mod commands;
@@ -11,12 +16,23 @@ mod infrastructure;
 
 use crate::core::GrimoireCSSError;
 use commands::process_mode_and_handle;
+use console::{style, Emoji};
+use indicatif::{ProgressBar, ProgressStyle};
 use infrastructure::LightningCSSOptimizer;
+use std::time::{Duration, Instant};
 
-/// Starts the Grimoire CSS system based on the given mode.
+pub static SUCCESS: Emoji<'_, '_> = Emoji("🪄", "✔️");
+pub static FAILURE: Emoji<'_, '_> = Emoji("☠️", "X");
+pub static INFO: Emoji<'_, '_> = Emoji("📖", "i");
+
+pub static SPINNER: [&str; 10] = ["🜁", "🜂", "🜃", "🜄", "✷", "☽", "☾", "🜇", "✶", ""];
+
+/// Starts the Grimoire CSS system based on the given mode,
+/// **without** performing any CLI-specific side effects.
 ///
-/// This function determines the current working directory, initializes the `LightningCSSOptimizer`,
-/// and then processes the mode, invoking the appropriate command handlers.
+/// This function determines the current working directory, initializes
+/// the `LightningCSSOptimizer`, and then processes the mode, invoking the
+/// appropriate command handlers.
 ///
 /// # Arguments
 ///
@@ -31,6 +47,15 @@ use infrastructure::LightningCSSOptimizer;
 ///
 /// This function returns a `GrimoireCSSError` if the current directory cannot be determined,
 /// the optimizer initialization fails, or the mode processing encounters an error.
+///
+/// # Examples
+///
+/// ```ignore
+/// use grimoire_css_lib::start;
+/// if let Err(e) = start("build".to_string()) {
+///     eprintln!("Error: {e}");
+/// }
+/// ```
 pub fn start(mode: String) -> Result<(), GrimoireCSSError> {
     let current_dir = std::env::current_dir()?;
     let css_optimizer = LightningCSSOptimizer::new(&current_dir)?;
@@ -39,7 +64,114 @@ pub fn start(mode: String) -> Result<(), GrimoireCSSError> {
 }
 
 /// Public function to read the saved messages from the buffer.
-/// This function is accessible from the main.rs for reading the buffer content.
+/// This function is accessible from the main.rs (or any other crate/binary)
+/// for reading the buffer content.
 pub fn get_logged_messages() -> Vec<String> {
     buffer::read_messages()
+}
+
+/// A convenience function that **simulates CLI behavior** (timing, logging, spinner)
+/// but is placed in the library crate to avoid duplicating code in multiple binaries
+/// or wrappers.
+///
+/// # Warning
+///
+/// - This is **not** an idiomatic approach for a typical Rust library since it
+///   introduces console-based side effects.
+/// - If you do not want logs, spinners, or colorized output, **do not** call this
+///   function. Instead, call [`start`] directly.
+/// - This function **depends** on `console` and `indicatif` crates for styling
+///   and progress-bar support, which might not be desired in all contexts.
+///
+/// # Arguments
+///
+/// * `args` - A vector of strings typically representing command-line arguments.
+///   The first argument is expected to be the binary name, and the second argument
+///   the mode (e.g. "build", "init").
+///
+/// # Returns
+///
+/// * `Ok(())` on success, or an `Err(GrimoireCSSError)` if invalid arguments or runtime
+///   issues occur.
+///
+/// # Examples
+///
+/// ```ignore
+/// use grimoire_css_lib::start_as_cli;
+///
+/// // Typically used in a real CLI setup:
+/// let args = vec!["grimoire_css".to_string(), "build".to_string()];
+/// if let Err(err) = start_as_cli(args) {
+///     eprintln!("Failed: {err}");
+/// }
+/// ```
+pub fn start_as_cli(args: Vec<String>) -> Result<(), GrimoireCSSError> {
+    let start_time = Instant::now();
+
+    println!("{} {}", INFO, style("Opened the Grimoire").blue().bold());
+
+    let pb = ProgressBar::new_spinner();
+    pb.set_message(style("Casting spells...").blue().italic().to_string());
+    pb.enable_steady_tick(Duration::from_millis(120));
+    pb.set_style(
+        ProgressStyle::default_spinner()
+            .tick_strings(&SPINNER)
+            .template("{spinner:.magenta} {msg}")
+            .unwrap(),
+    );
+
+    // Check if the user provided at least one argument (mode)
+    if args.len() < 2 {
+        pb.finish();
+        return Err(GrimoireCSSError::InvalidInput(format!(
+            "{}\n    Follow: {} <mode>",
+            style(format!("{} Wrong usage!", FAILURE)).red().bold(),
+            style(&args[0]).yellow().italic()
+        )));
+    }
+
+    // Proceed with the main function, passing the first argument (mode)
+    match start(args[1].to_owned()) {
+        Ok(_) => {
+            pb.finish_and_clear();
+            output_saved_messages();
+
+            let duration = start_time.elapsed();
+            println!(
+                "{}",
+                style(format!("✨ Magic complete in {:.2?}!", duration))
+                    .magenta()
+                    .bold()
+            );
+            Ok(())
+        }
+        Err(e) => {
+            pb.finish();
+
+            println!(
+                "{}",
+                style(format!(
+                    "{} Dark magic interfered!\n {}",
+                    FAILURE,
+                    e.to_string()
+                ))
+                .red()
+                .bold()
+            );
+
+            Err(e)
+        }
+    }
+}
+
+fn output_saved_messages() {
+    let messages = get_logged_messages();
+
+    if !messages.is_empty() {
+        println!("{}", style("History:").dim().bold());
+
+        for msg in messages.iter() {
+            println!("{} {}", style("    •").dim(), style(msg).dim());
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,13 +150,9 @@ pub fn start_as_cli(args: Vec<String>) -> Result<(), GrimoireCSSError> {
 
             println!(
                 "{}",
-                style(format!(
-                    "{} Dark magic interfered!\n {}",
-                    FAILURE,
-                    e.to_string()
-                ))
-                .red()
-                .bold()
+                style(format!("{} Dark magic interfered!\n {}", FAILURE, e))
+                    .red()
+                    .bold()
             );
 
             Err(e)

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ fn main() {
 
     // By calling `start_as_cli`, we rely on the library's built-in logging,
     // progress bar, and error-handling logic.
-    if let Err(_) = start_as_cli(args) {
+    if start_as_cli(args).is_err() {
         std::process::exit(1);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,89 +1,25 @@
 //! The main executable entry point for the Grimoire CSS system.
 //!
 //! This file handles command-line argument parsing and initiates the main processing by calling
-//! the `start` function from the core library. It ensures that errors are handled gracefully
-//! and reported to the user with styled output.
+//! the [`start_as_cli`] function from the core library. It ensures that errors are handled gracefully
+//! and reported to the user by returning a non-zero status code on failure.
 
-use console::{style, Emoji};
-use grimoire_css_lib::{get_logged_messages, start};
-use indicatif::{ProgressBar, ProgressStyle};
+use grimoire_css_lib::start_as_cli;
 use std::env;
-use std::time::{Duration, Instant};
 
-pub static SUCCESS: Emoji<'_, '_> = Emoji("🪄", "✔️");
-pub static FAILURE: Emoji<'_, '_> = Emoji("☠️", "X");
-pub static INFO: Emoji<'_, '_> = Emoji("📖", "i");
-
-pub static SPINNER: [&str; 10] = ["🜁", "🜂", "🜃", "🜄", "✷", "☽", "☾", "🜇", "✶", ""];
-
-/// The entry point for the Grimoire CSS system.
+/// The entry point for the Grimoire CSS system (CLI).
 ///
-/// This function collects command-line arguments, passes the first argument as the mode to the
-/// `start` function from the core library, and handles any errors that occur during execution.
-///
-/// If an error is encountered, it prints the error message to `stderr` and exits with a non-zero status code.
+/// This function:
+/// - Collects command-line arguments.
+/// - Passes them into [`start_as_cli`] from the core library, which handles
+///   logging, error styling, spinners, and time measurements.
+/// - If an error is encountered, it exits with a non-zero status code.
 fn main() {
     let args: Vec<String> = env::args().collect();
 
-    let start_time = Instant::now();
-
-    println!("{} {}", INFO, style("Opened the Grimoire").blue().bold());
-
-    let pb = ProgressBar::new_spinner();
-    pb.set_message(style("Casting spells...").blue().italic().to_string());
-    pb.enable_steady_tick(Duration::from_millis(120));
-    pb.set_style(
-        ProgressStyle::default_spinner()
-            .tick_strings(&SPINNER)
-            .template("{spinner:.magenta} {msg}")
-            .unwrap(),
-    );
-
-    // Check if the user provided at least one argument (mode)
-    if args.len() < 2 {
-        let message = style(format!("{} Wrong usage!", FAILURE)).red().bold();
-        let example = style(format!("Follow: {} <mode>", args[0]))
-            .yellow()
-            .italic();
-
-        pb.finish();
-        eprintln!("{}\n    {}", message, example);
+    // By calling `start_as_cli`, we rely on the library's built-in logging,
+    // progress bar, and error-handling logic.
+    if let Err(_) = start_as_cli(args) {
         std::process::exit(1);
-    }
-
-    // Proceed with the main function, passing the first argument (mode)
-    match start(args[1].to_owned()) {
-        Ok(_) => {
-            pb.finish_and_clear();
-
-            output_saved_messages();
-
-            let duration = start_time.elapsed();
-            println!(
-                "{}",
-                style(format!("✨ Magic complete in {:.2?}!", duration))
-                    .magenta()
-                    .bold()
-            );
-        }
-        Err(e) => {
-            let message = style(format!("{} Dark magic interfered!\n {}", FAILURE, e))
-                .red()
-                .bold();
-            pb.finish();
-            eprintln!("{}", style(format!("{}", message)).red().bold());
-            std::process::exit(1);
-        }
-    }
-}
-fn output_saved_messages() {
-    let messages = get_logged_messages();
-
-    if !messages.is_empty() {
-        println!("{}", style("History:").dim().bold());
-
-        for msg in messages.iter() {
-            println!("{} {}", style("    •").dim(), style(msg).dim());
-        }
     }
 }


### PR DESCRIPTION
## Key changes

The main library module now provides:
- A **pure** function `start` that executes the core logic of Grimoire CSS without printing or side effects.
- A **convenience** function [`start_as_cli`] for CLI usage. It includes logging, timing, and user-facing output (spinners, styled text), but is _not idiomatic_ for a typical Rust library because it introduces side effects and depends on console/UI crates. Use it only if you specifically want the same CLI behavior outside of the main binary (e.g. in a Node.js wrapper).