### PR TITLE
refactor: simplify argument handling in start_as_cli function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,13 +117,12 @@ pub fn get_logged_messages() -> Vec<String> {
 ///     eprintln!("Failed: {err}");
 /// }
 /// ```
-pub fn start_as_cli(args: &[String]) -> Result<(), GrimoireCssError> {
-    let start_time = Instant::now();
-
+pub fn start_as_cli(args: Vec<String>) -> Result<(), GrimoireCssError> {
     // print empty line for better readability
     println!();
 
-    if args.is_empty() {
+    // Check if the user provided at least one argument (mode)
+    if args.len() < 2 {
         let message = format!(
             "{}\n    {} ",
             style(format!("{} Wrong usage!", FAILURE)).red().bold(),
@@ -150,8 +149,10 @@ pub fn start_as_cli(args: &[String]) -> Result<(), GrimoireCssError> {
             .unwrap(),
     );
 
+    let start_time = Instant::now();
+
     // Proceed with the main function, passing the first argument (mode)
-    match start(&args[0]) {
+    match start(args[1].as_str()) {
         Ok(_) => {
             pb.finish_and_clear();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,9 +15,11 @@ use std::env;
 ///   logging, error styling, spinners, and time measurements.
 /// - If an error is encountered, it exits with a non-zero status code.
 fn main() {
-    let args: Vec<_> = env::args().skip(1).collect();
+    let args: Vec<String> = env::args().collect();
 
-    if start_as_cli(&args).is_err() {
+    // By calling `start_as_cli`, we rely on the library's built-in logging,
+    // progress bar, and error-handling logic.
+    if start_as_cli(args).is_err() {
         std::process::exit(1);
     }
 }


### PR DESCRIPTION
- Changed `start_as_cli` function signature from `&[String]` to `Vec<String>`
- Added proper argument validation
- Updated `main.rs` to use full `env::args()` collection

---

Closes #65 