### PR TITLE
Template support for scroll usage

### DIFF
--- a/src/core/css_builder/css_builder_in_memory.rs
+++ b/src/core/css_builder/css_builder_in_memory.rs
@@ -147,4 +147,87 @@ mod tests {
         assert_eq!(result[0].name, "test");
         assert!(result[0].content.eq(".display\\=flex{display:flex;}"));
     }
+
+    #[test]
+    fn test_builder_with_templated_scroll_invocation() {
+        let mut scrolls_map: HashMap<String, Vec<String>> = HashMap::new();
+        scrolls_map.insert(
+            "complex-card".to_string(),
+            vec!["h=$".to_string(), "c=$".to_string(), "w=$".to_string()],
+        );
+
+        let config = ConfigInMemory {
+            projects: vec![ConfigInMemoryEntry {
+                name: "test".to_string(),
+                content: vec!["<div g!complex-card=120px_red_100px;></div>".to_string()],
+            }],
+            variables: None,
+            scrolls: Some(scrolls_map),
+            custom_animations: HashMap::new(),
+            browserslist_content: None,
+        };
+
+        let optimizer = MockOptimizer;
+        let mut builder = CssBuilderInMemory::new(&config, &optimizer).unwrap();
+        let result = builder.build().unwrap();
+
+        assert_eq!(result.len(), 1);
+        let css = &result[0].content;
+
+        // The output must use the outer template selector, not the inner scroll spell selectors.
+        assert!(css.contains(".g\\!complex-card\\=120px\\_red\\_100px\\;{height:120px;}"));
+        assert!(css.contains(".g\\!complex-card\\=120px\\_red\\_100px\\;{color:red;}"));
+        assert!(css.contains(".g\\!complex-card\\=120px\\_red\\_100px\\;{width:100px;}"));
+
+        assert!(!css.contains(".h\\=120px"));
+        assert!(!css.contains(".c\\=red"));
+        assert!(!css.contains(".w\\=100px"));
+    }
+
+    #[test]
+    fn test_builder_with_templated_scroll_invocation_with_prefixes() {
+        let mut scrolls_map: HashMap<String, Vec<String>> = HashMap::new();
+        scrolls_map.insert(
+            "complex-card".to_string(),
+            vec!["h=$".to_string(), "c=$".to_string(), "w=$".to_string()],
+        );
+
+        let config = ConfigInMemory {
+            projects: vec![ConfigInMemoryEntry {
+                name: "test".to_string(),
+                // Prefixes live on the scroll invocation and must apply to all expanded spells.
+                // - md__      => @media (min-width: 768px)
+                // - hover:    => :hover pseudo
+                // - {_>_p}    => " > p" focus selector
+                content: vec![
+                    "<div g!md__{_>_p}hover:complex-card=120px_red_100px;></div>".to_string(),
+                ],
+            }],
+            variables: None,
+            scrolls: Some(scrolls_map),
+            custom_animations: HashMap::new(),
+            browserslist_content: None,
+        };
+
+        let optimizer = MockOptimizer;
+        let mut builder = CssBuilderInMemory::new(&config, &optimizer).unwrap();
+        let result = builder.build().unwrap();
+
+        assert_eq!(result.len(), 1);
+        let css = &result[0].content;
+
+        // Ensure the area prefix becomes a media query.
+        assert!(css.contains("@media (min-width: 768px)"));
+        // Ensure effects+focus survive the selector replacement.
+        assert!(css.contains(":hover > p"));
+
+        // Ensure the outer template selector is used (not inner h=/c=/w= selectors).
+        assert!(css.contains(
+            ".g\\!md\\_\\_\\{\\_\\>\\_p\\}hover\\:complex-card\\=120px\\_red\\_100px\\;"
+        ));
+
+        assert!(!css.contains(".md\\_\\_\\{\\_\\>\\_p\\}hover\\:h\\=120px"));
+        assert!(!css.contains(".md\\_\\_\\{\\_\\>\\_p\\}hover\\:c\\=red"));
+        assert!(!css.contains(".md\\_\\_\\{\\_\\>\\_p\\}hover\\:w\\=100px"));
+    }
 }


### PR DESCRIPTION
This change adds template support for config-defined `scrolls` in `g!…;` syntax, including variable arguments and prefix modifiers, while keeping output deterministic and reducing unnecessary cloning.

**Overview:**
- Enabled using scrolls inside `g!…;`, e.g. `g!complex-card=120px_red_100px;`.
- Flattened scroll expansion into real property spells so CSS is generated under the outer templated selector.
- Preserved prefix semantics (`md__`, `{...}` focus, `hover:` effects) by applying them to each expanded spell.
- Reduced clone pressure in the template-flattening path.

**Tests:**
- Added unit coverage for parsing `g!<scroll>=...;`.
- Added end-to-end in-memory builder tests covering both plain and prefixed cases (`md__{...}hover:`).

---

closes #99 